### PR TITLE
Use new `ruff check` invocation requirement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,9 +35,9 @@ jobs:
         run: |
           pip install ruff
           # stop the build if there are Python syntax errors or undefined names
-          ruff --output-format=github --select=E9,F63,F7,F82 .
+          ruff check --output-format=github --select=E9,F63,F7,F82 .
           # default set of ruff rules with GitHub Annotations
-          ruff --output-format=github .
+          ruff check --output-format=github .
       - name: Test with pytest
         run: |
           pip install pytest


### PR DESCRIPTION
CI is currently failing because the ruff version isn't controlled; a new version was released and requires the command to be `ruff check`.

This PR addresses the issue.