### PR TITLE
Address CI deprecation warnings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,9 @@ jobs:
           - "3.10"
           - "3.11"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
CI is throwing deprecation warnings ([recent example](https://github.com/sqids/sqids-python/actions/runs/10162347850)):

> ![image](https://github.com/user-attachments/assets/aa6810ac-8b36-417e-9b5f-60640cc904ca)

This PR updates the CI versions to address the warnings. Note that it will be beneficial to use Dependabot (or similar) to keep the actions updated via auto-submitted PRs. If you want help with that, just let me know.