### PR TITLE
Remove an unnecessary conditional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ source = [
 
 [tool.coverage.report]
 skip_covered = true
-fail_under = 99
+fail_under = 100
 
 [tool.coverage.html]
 directory = "htmlcov/"

--- a/sqids/sqids.py
+++ b/sqids/sqids.py
@@ -110,13 +110,12 @@ class Sqids:
         while id_:
             separator = alphabet[0]
             chunks = id_.split(separator)
-            if chunks:
-                if not chunks[0]:
-                    return ret
+            if not chunks[0]:
+                return ret
 
-                ret.append(self.__to_number(chunks[0], alphabet[1:]))
-                if len(chunks) > 1:
-                    alphabet = self.__shuffle(alphabet)
+            ret.append(self.__to_number(chunks[0], alphabet[1:]))
+            if len(chunks) > 1:
+                alphabet = self.__shuffle(alphabet)
 
             id_ = separator.join(chunks[1:])
 


### PR DESCRIPTION
This PR removes the `if chunks:` conditional and dedents the conditional block, since `if chunks:` is always True. Removing the conditional allows the test coverage fail-under value to increase to 100%; previously it was at 99% because the conditional branch never evaluated to `False`, so branch coverage wasn't complete.

> ![image](https://github.com/user-attachments/assets/aab0d8a7-7d20-4532-bc9c-eb8a39ce1595)


It's easy to confirm that the condition will always be `True`, even when the string being split is empty:

```pycon
>>> "".split("a")
['']
>>> bool("".split("a"))
True
```
