### PR TITLE
Export Sqids from sqids module

### DIFF
--- a/sqids/__init__.py
+++ b/sqids/__init__.py
@@ -1,1 +1,3 @@
-from .sqids import Sqids  # noqa: F401
+from .sqids import Sqids
+
+__all__ = ["Sqids"]


### PR DESCRIPTION
The previous code did not export the Sqids class leading to private import usage warnings when using `from sqids import Sqids`. One could work around it by using `from sqids.sqids import Sqids`. This workaround is now no longer necessary.